### PR TITLE
Updated tslint peer dependency request

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^2.2.1"
   },
   "peerDependencies": {
-    "tslint": ">=4.5.1  >=5.2.0"
+    "tslint": ">=4.5.1  >=5.5.0"
   },
   "dependencies": {
     "rimraf": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^2.2.1"
   },
   "peerDependencies": {
-    "tslint": ">=4.5.1  >=5.5.0"
+    "tslint": ">=4.5.1  <=5.5.0"
   },
   "dependencies": {
     "rimraf": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-jasmine-noSkipOrFocus",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Linting rules to disallow focused or skipped tests.",
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",
@@ -46,7 +46,7 @@
     "typescript": "^2.2.1"
   },
   "peerDependencies": {
-    "tslint": "4.5.1-5.2.0"
+    "tslint": "4.5.1 - 5.2.0"
   },
   "dependencies": {
     "rimraf": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^2.2.1"
   },
   "peerDependencies": {
-    "tslint": "4.5.1 - 5.2.0"
+    "tslint": ">=4.5.1  >=5.2.0"
   },
   "dependencies": {
     "rimraf": "^2.6.1"


### PR DESCRIPTION
The peer dependency request for `tslint` was written in such a way that NPM was asking for the wrong version. This is fixed in this pr, and tested with the latest version of `tslint`: `5.5.0`