### PR TITLE
Updating tslint peer dependencies to be less strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^2.2.1"
   },
   "peerDependencies": {
-    "tslint": ">=4.5.1  <=5.5.0"
+    "tslint": ">=4.5.1  <6.0.0"
   },
   "dependencies": {
     "rimraf": "^2.6.1"


### PR DESCRIPTION
tslint is updated pretty frequently, and having this tied to a specific version means it's constantly out of date. I verified that it works with tslint 5.6 and 5.7, and I think it's safe to assume with semver that  it should work with all 5.x versions of tslint, at least.